### PR TITLE
Fix unit tests for config flow, ensure that device_id is string

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1168,6 +1168,7 @@ omit =
     homeassistant/components/yandex_transport/*
     homeassistant/components/yeelightsunflower/light.py
     homeassistant/components/yi/camera.py
+    homeassistant/components/youless/*
     homeassistant/components/zabbix/*
     homeassistant/components/zamg/sensor.py
     homeassistant/components/zamg/weather.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1168,7 +1168,9 @@ omit =
     homeassistant/components/yandex_transport/*
     homeassistant/components/yeelightsunflower/light.py
     homeassistant/components/yi/camera.py
-    homeassistant/components/youless/*
+    homeassistant/components/youless/__init__.py
+    homeassistant/components/youless/const.py
+    homeassistant/components/youless/sensor.py
     homeassistant/components/zabbix/*
     homeassistant/components/zamg/sensor.py
     homeassistant/components/zamg/weather.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -554,6 +554,7 @@ homeassistant/components/yandex_transport/* @rishatik92 @devbis
 homeassistant/components/yeelight/* @rytilahti @zewelor @shenxn
 homeassistant/components/yeelightsunflower/* @lindsaymarkward
 homeassistant/components/yi/* @bachya
+homeassistant/components/youless/* @gjong
 homeassistant/components/zeroconf/* @bdraco
 homeassistant/components/zerproc/* @emlove
 homeassistant/components/zha/* @dmulcahey @adminiuga

--- a/homeassistant/components/youless/__init__.py
+++ b/homeassistant/components/youless/__init__.py
@@ -2,34 +2,32 @@
 import asyncio
 from urllib.error import URLError
 
-import voluptuous as vol
 from youless_api import YoulessAPI
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
-from ...exceptions import PlatformNotReady
 from .const import DOMAIN
 
-CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the youless component."""
     hass.data[DOMAIN] = {}
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up youless from a config entry."""
     api = YoulessAPI(entry.data[CONF_HOST])
 
     try:
         await hass.async_add_executor_job(api.initialize)
     except URLError as exception:
-        raise PlatformNotReady from exception
+        raise ConfigEntryNotReady from exception
 
     hass.data[DOMAIN][entry.entry_id] = api
     for component in PLATFORMS:
@@ -40,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(

--- a/homeassistant/components/youless/__init__.py
+++ b/homeassistant/components/youless/__init__.py
@@ -26,8 +26,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up youless from a config entry."""
     try:
         hass.data[DOMAIN][entry.entry_id] = YoulessAPI(entry.data[CONF_HOST])
-    except URLError:
-        raise PlatformNotReady
+    except URLError as exception:
+        raise PlatformNotReady from exception
 
     for component in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/youless/__init__.py
+++ b/homeassistant/components/youless/__init__.py
@@ -1,0 +1,53 @@
+"""The youless integration."""
+import asyncio
+from urllib.error import URLError
+
+import voluptuous as vol
+from youless_api import YoulessAPI
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
+
+from .const import DOMAIN
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+PLATFORMS = ["sensor"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the youless component."""
+    hass.data[DOMAIN] = {}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up youless from a config entry."""
+    try:
+        hass.data[DOMAIN][entry.entry_id] = YoulessAPI(entry.data[CONF_HOST])
+    except URLError:
+        raise PlatformNotReady
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -30,7 +30,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(api.initialize)
 
                 device_id = config_entries.uuid_util.random_uuid_hex()
-                if api.mac_address is not None:
+                if api.mac_address is not None and isinstance(api.mac_address, str):
                     device_id = api.mac_address
 
                 return self.async_create_entry(

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -52,9 +52,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 _LOGGER.exception("Cannot connect to host")
                 errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -3,7 +3,7 @@ import logging
 from urllib.error import HTTPError, URLError
 
 import voluptuous as vol
-from youless_api.youless_api import YoulessAPI
+from youless_api import YoulessAPI
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_NAME

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -18,7 +18,8 @@ DATA_SCHEMA = vol.Schema({vol.Required(CONF_NAME): str, vol.Required(CONF_HOST):
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input using the API connector."""
     try:
-        YoulessAPI(data[CONF_HOST])
+        api = YoulessAPI(data[CONF_HOST])
+        await hass.async_add_executor_job(api.initialize)
     except HTTPError as exception:
         raise CannotConnect() from exception
     except URLError as exception:

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -1,0 +1,66 @@
+"""Config flow for youless integration."""
+import logging
+from urllib.error import HTTPError, URLError
+
+import voluptuous as vol
+from youless_api.youless_api import YoulessAPI
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_NAME
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_NAME): str, vol.Required(CONF_HOST): str})
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input using the API connector."""
+    hub = YoulessAPI(data[CONF_HOST])
+
+    try:
+        hub.update()
+    except HTTPError:
+        raise CannotConnect()
+    except URLError:
+        raise CannotConnect()
+
+    return {"title": data[CONF_NAME]}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for youless."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(
+                    title=info["title"],
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_NAME: user_input[CONF_NAME],
+                        CONF_DEVICE: user_input[CONF_NAME],
+                    },
+                )
+            except CannotConnect:
+                _LOGGER.exception("Cannot connect to host")
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -17,14 +17,12 @@ DATA_SCHEMA = vol.Schema({vol.Required(CONF_NAME): str, vol.Required(CONF_HOST):
 
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input using the API connector."""
-    hub = YoulessAPI(data[CONF_HOST])
-
     try:
-        hub.update()
-    except HTTPError:
-        raise CannotConnect()
-    except URLError:
-        raise CannotConnect()
+        YoulessAPI(data[CONF_HOST])
+    except HTTPError as exception:
+        raise CannotConnect() from exception
+    except URLError as exception:
+        raise CannotConnect() from exception
 
     return {"title": data[CONF_NAME]}
 

--- a/homeassistant/components/youless/const.py
+++ b/homeassistant/components/youless/const.py
@@ -1,0 +1,3 @@
+"""Constants for the youless integration."""
+
+DOMAIN = "youless"

--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -6,10 +6,6 @@
   "requirements": [
     "youless-api==0.7"
   ],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": [
     "@gjong"
   ]

--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/youless",
   "requirements": [
-    "youless-api==0.5"
+    "youless-api==0.7"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/youless",
   "requirements": [
-    "youless-api==0.4"
+    "youless-api==0.5"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/youless",
   "requirements": [
-    "youless-api==0.3"
+    "youless-api==0.4"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "youless",
+  "name": "YouLess",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/youless",
+  "requirements": [
+    "youless-api==0.3"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@gjong"
+  ]
+}

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -8,7 +8,7 @@ from youless_api.youless_sensor import YoulessSensor
 from homeassistant import core
 from homeassistant.components.youless import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_DEVICE, DEVICE_CLASS_POWER
+from homeassistant.const import CONF_DEVICE, DEVICE_CLASS_POWER
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import Throttle
@@ -70,11 +70,6 @@ class YoulessBaseSensor(Entity):
             return None
 
         return self.get_sensor.value
-
-    @property
-    def state_attributes(self) -> Optional[Dict[str, Any]]:
-        """Return the state attributes."""
-        return {ATTR_FRIENDLY_NAME: self._friendly_name}
 
     @property
     def unique_id(self) -> Optional[str]:

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -126,7 +126,7 @@ class CurrentPowerSensor(YoulessBaseSensor):
     @property
     def name(self) -> Optional[str]:
         """Return the name of the meter."""
-        return f"{self._device} ssage"
+        return f"{self._device} Usage"
 
     @property
     def get_sensor(self) -> Optional[YoulessSensor]:

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -152,10 +152,12 @@ class CurrentPowerSensor(YoulessBaseSensor):
 class DeliveryMeterSensor(YoulessBaseSensor):
     """The Youless delivery meter value sensor."""
 
-    def __init__(self, gateway: YoulessAPI, device: str, type: str):
+    def __init__(self, gateway: YoulessAPI, device: str, dev_type: str):
         """Instantiate a delivery meter sensor."""
-        super().__init__(gateway, device, f"Delivery meter {type}", f"delivery_{type}")
-        self._type = type
+        super().__init__(
+            gateway, device, f"Delivery meter {dev_type}", f"delivery_{dev_type}"
+        )
+        self._type = dev_type
 
     @property
     def name(self) -> Optional[str]:
@@ -184,11 +186,13 @@ class DeliveryMeterSensor(YoulessBaseSensor):
 class PowerMeterSensor(YoulessBaseSensor):
     """The Youless low meter value sensor."""
 
-    def __init__(self, gateway: YoulessAPI, device: str, type: str):
+    def __init__(self, gateway: YoulessAPI, device: str, dev_type: str):
         """Instantiate a power meter sensor."""
-        super().__init__(gateway, device, f"Power meter {type}", f"power_{type}")
+        super().__init__(
+            gateway, device, f"Power meter {dev_type}", f"power_{dev_type}"
+        )
         self._device = device
-        self._type = type
+        self._type = dev_type
 
     @property
     def name(self) -> Optional[str]:

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -1,0 +1,214 @@
+"""The sensor entity for the Youless integration."""
+from datetime import timedelta
+from typing import Any, Dict, Optional
+
+from youless_api import YoulessAPI
+from youless_api.youless_sensor import YoulessSensor
+
+from homeassistant import core
+from homeassistant.components.youless import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_DEVICE, DEVICE_CLASS_POWER
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import StateType
+from homeassistant.util import Throttle
+
+
+async def async_setup_entry(
+    hass: core.HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Initialize the integration."""
+    gateway = hass.data[DOMAIN][entry.entry_id]
+    device = entry.data[CONF_DEVICE]
+    sensors = [
+        GasSensor(gateway, device),
+        PowerMeterSensor(gateway, device, "low"),
+        PowerMeterSensor(gateway, device, "high"),
+        PowerMeterSensor(gateway, device, "total"),
+        CurrentPowerSensor(gateway, device),
+        DeliveryMeterSensor(gateway, device, "total"),
+        DeliveryMeterSensor(gateway, device, "current"),
+    ]
+
+    async_add_entities(sensors)
+
+
+class YoulessBaseSensor(Entity):
+    """The base sensor for Youless."""
+
+    def __init__(
+        self, gateway: YoulessAPI, device: str, friendly_name: str, sensor_id: str
+    ):
+        """Create the sensor."""
+        self._gateway = gateway
+        self._friendly_name = friendly_name
+        self._device = device
+        self._sensor_id = sensor_id
+
+    @Throttle(timedelta(seconds=30))
+    def update(self) -> None:
+        """Update the gateway value."""
+        self._gateway.update()
+
+    @property
+    def get_sensor(self) -> Optional[YoulessSensor]:
+        """Property to get the underlying sensor object."""
+        return None
+
+    @property
+    def unit_of_measurement(self) -> Optional[str]:
+        """Return the unit of measurement for the sensor."""
+        if self.get_sensor is None:
+            return None
+
+        return self.get_sensor.unit_of_measurement
+
+    @property
+    def state(self) -> StateType:
+        """Determine the state value, only if a sensor is initialized."""
+        if self.get_sensor is None:
+            return None
+
+        return self.get_sensor.value
+
+    @property
+    def state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return the state attributes."""
+        return {ATTR_FRIENDLY_NAME: self._friendly_name}
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return the uniquely generated id."""
+        return f"{DOMAIN}_{self._device}_{self._sensor_id}"
+
+    @property
+    def available(self) -> bool:
+        """Return a flag to indicate the sensor not being available."""
+        return self.get_sensor is not None
+
+    @property
+    def device_info(self) -> Optional[Dict[str, Any]]:
+        """Return the device information."""
+        return {
+            "identifiers": {(DOMAIN, self._gateway.mac_address)},
+            "name": self._device,
+            "manufacturer": "YouLess",
+            "model": self._gateway.model,
+        }
+
+
+class GasSensor(YoulessBaseSensor):
+    """The Youless gas sensor."""
+
+    def __init__(self, gateway: YoulessAPI, device: str):
+        """Instantiate a gas sensor."""
+        super().__init__(gateway, device, "Gas meter", "gas")
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the meter."""
+        return f"{self._device} gas"
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:fire"
+
+    @property
+    def get_sensor(self) -> Optional[YoulessSensor]:
+        """Get the sensor for providing the value."""
+        return self._gateway.gas_meter
+
+
+class CurrentPowerSensor(YoulessBaseSensor):
+    """The current power usage sensor."""
+
+    def __init__(self, gateway: YoulessAPI, device: str):
+        """Instantiate the usage meter."""
+        super().__init__(gateway, device, "Power usage", "usage")
+        self._device = device
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the meter."""
+        return f"{self._device} ssage"
+
+    @property
+    def get_sensor(self) -> Optional[YoulessSensor]:
+        """Get the sensor for providing the value."""
+        return self._gateway.current_power_usage
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_POWER
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:power-socket"
+
+
+class DeliveryMeterSensor(YoulessBaseSensor):
+    """The Youless delivery meter value sensor."""
+
+    def __init__(self, gateway: YoulessAPI, device: str, type: str):
+        """Instantiate a delivery meter sensor."""
+        super().__init__(gateway, device, f"Delivery meter {type}", f"delivery_{type}")
+        self._type = type
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the meter."""
+        return f"{self._device} delivery {self._type}"
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:counter"
+
+    @property
+    def get_sensor(self) -> Optional[YoulessSensor]:
+        """Get the sensor for providing the value."""
+        if self._gateway.delivery_meter is None:
+            return None
+
+        return getattr(self._gateway.delivery_meter, f"_{self._type}", None)
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_POWER
+
+
+class PowerMeterSensor(YoulessBaseSensor):
+    """The Youless low meter value sensor."""
+
+    def __init__(self, gateway: YoulessAPI, device: str, type: str):
+        """Instantiate a power meter sensor."""
+        super().__init__(gateway, device, f"Power meter {type}", f"power_{type}")
+        self._device = device
+        self._type = type
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the meter."""
+        return f"{self._device} power {self._type}"
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:counter"
+
+    @property
+    def get_sensor(self) -> Optional[YoulessSensor]:
+        """Get the sensor for providing the value."""
+        if self._gateway.power_meter is None:
+            return None
+
+        return getattr(self._gateway.power_meter, f"_{self._type}", None)
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_POWER

--- a/homeassistant/components/youless/strings.json
+++ b/homeassistant/components/youless/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "YouLess",
   "config": {
     "step": {
       "user": {
@@ -10,12 +9,7 @@
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   }
 }

--- a/homeassistant/components/youless/strings.json
+++ b/homeassistant/components/youless/strings.json
@@ -1,0 +1,21 @@
+{
+  "title": "YouLess",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/youless/translations/en.json
+++ b/homeassistant/components/youless/translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "username": "Username"
+                }
+            }
+        }
+    },
+    "title": "youless"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -271,6 +271,7 @@ FLOWS = [
     "xiaomi_aqara",
     "xiaomi_miio",
     "yeelight",
+    "youless",
     "zerproc",
     "zha",
     "zwave",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2366,7 +2366,7 @@ yeelight==0.5.4
 yeelightsunflower==0.0.10
 
 # homeassistant.components.youless
-youless-api==0.4
+youless-api==0.5
 
 # homeassistant.components.media_extractor
 youtube_dl==2021.03.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2366,7 +2366,7 @@ yeelight==0.5.4
 yeelightsunflower==0.0.10
 
 # homeassistant.components.youless
-youless-api==0.3
+youless-api==0.4
 
 # homeassistant.components.media_extractor
 youtube_dl==2021.03.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2366,7 +2366,7 @@ yeelight==0.5.4
 yeelightsunflower==0.0.10
 
 # homeassistant.components.youless
-youless-api==0.5
+youless-api==0.7
 
 # homeassistant.components.media_extractor
 youtube_dl==2021.03.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2365,6 +2365,9 @@ yeelight==0.5.4
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10
 
+# homeassistant.components.youless
+youless-api==0.3
+
 # homeassistant.components.media_extractor
 youtube_dl==2021.03.14
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1248,7 +1248,7 @@ yalexs==1.1.10
 yeelight==0.5.4
 
 # homeassistant.components.youless
-youless-api==0.5
+youless-api==0.7
 
 # homeassistant.components.onvif
 zeep[async]==4.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1248,7 +1248,7 @@ yalexs==1.1.10
 yeelight==0.5.4
 
 # homeassistant.components.youless
-youless-api==0.4
+youless-api==0.5
 
 # homeassistant.components.onvif
 zeep[async]==4.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1248,7 +1248,7 @@ yalexs==1.1.10
 yeelight==0.5.4
 
 # homeassistant.components.youless
-youless-api==0.3
+youless-api==0.4
 
 # homeassistant.components.onvif
 zeep[async]==4.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1247,6 +1247,9 @@ yalexs==1.1.10
 # homeassistant.components.yeelight
 yeelight==0.5.4
 
+# homeassistant.components.youless
+youless-api==0.3
+
 # homeassistant.components.onvif
 zeep[async]==4.0.0
 

--- a/tests/components/youless/__init__.py
+++ b/tests/components/youless/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the youless component."""

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -1,17 +1,18 @@
 """Test the youless config flow."""
 from unittest.mock import MagicMock, patch
+from urllib.error import URLError
 
 from homeassistant import config_entries
 from homeassistant.components.youless import DOMAIN
 from homeassistant.data_entry_flow import RESULT_TYPE_FORM
 
 
-def _get_mock_youless_api(getMe=None):
+def _get_mock_youless_api(initialize=None):
     mock_youless = MagicMock()
-    if isinstance(getMe, Exception):
-        type(mock_youless).getMe = MagicMock(side_effect=getMe)
+    if isinstance(initialize, Exception):
+        type(mock_youless).initialize = MagicMock(side_effect=initialize)
     else:
-        type(mock_youless).getMe = MagicMock(return_value=getMe)
+        type(mock_youless).initialize = MagicMock(return_value=initialize)
     return mock_youless
 
 
@@ -25,7 +26,9 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     assert result["errors"] == {}
     assert result["step_id"] == config_entries.SOURCE_USER
 
-    mock_youless = _get_mock_youless_api(getMe={"homes": [{"id": 1, "name": "myhome"}]})
+    mock_youless = _get_mock_youless_api(
+        initialize={"homes": [{"id": 1, "name": "myhome"}]}
+    )
     with patch(
         "homeassistant.components.youless.config_flow.YoulessAPI",
         return_value=mock_youless,
@@ -38,4 +41,28 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "YouLess Sensor"
     await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_not_found(hass, aiohttp_client, aioclient_mock, current_request):
+    """Check setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == config_entries.SOURCE_USER
+
+    mock_youless = _get_mock_youless_api(initialize=URLError(""))
+    with patch(
+        "homeassistant.components.youless.config_flow.YoulessAPI",
+        return_value=mock_youless,
+    ) as mock_setup:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "localhost", "name": "YouLess Sensor"},
+        )
+
+    assert result2["type"] == "form"
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -1,11 +1,18 @@
 """Test the youless config flow."""
+from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.youless import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.data_entry_flow import RESULT_TYPE_FORM
 
-MOCK_CONFIG = {CONF_HOST: "172.0.0.1", CONF_NAME: "Test setup"}
+
+def _get_mock_youless_api(getMe=None):
+    mock_youless = MagicMock()
+    if isinstance(getMe, Exception):
+        type(mock_youless).getMe = MagicMock(side_effect=getMe)
+    else:
+        type(mock_youless).getMe = MagicMock(return_value=getMe)
+    return mock_youless
 
 
 async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
@@ -17,3 +24,18 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
     assert result["step_id"] == config_entries.SOURCE_USER
+
+    mock_youless = _get_mock_youless_api(getMe={"homes": [{"id": 1, "name": "myhome"}]})
+    with patch(
+        "homeassistant.components.youless.config_flow.YoulessAPI",
+        return_value=mock_youless,
+    ) as mock_setup:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "localhost", "name": "YouLess Sensor"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "YouLess Sensor"
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -1,33 +1,11 @@
 """Test the youless config flow."""
-from unittest.mock import patch
-from urllib.error import HTTPError
-
-import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.youless import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
-from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.data_entry_flow import RESULT_TYPE_FORM
 
 MOCK_CONFIG = {CONF_HOST: "172.0.0.1", CONF_NAME: "Test setup"}
-
-
-@pytest.fixture(autouse=True)
-def mock_dummy_tcp_server():
-    """Mock a YouLess device."""
-
-    class Dummy:
-        async def start_server(self):
-            raise HTTPError
-
-        async def close_server(self):
-            pass
-
-    server = Dummy()
-    with patch(
-        "homeassistant.components.youless.config_flow.YoulessAPI", return_value=server
-    ):
-        yield server
 
 
 async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
@@ -39,9 +17,3 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
     assert result["step_id"] == config_entries.SOURCE_USER
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_CONFIG,
-    )
-    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -1,0 +1,47 @@
+"""Test the youless config flow."""
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.youless import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+MOCK_CONFIG = {CONF_HOST: "172.0.0.1", CONF_NAME: "Test setup"}
+
+
+@pytest.fixture(autouse=True)
+def mock_dummy_tcp_server():
+    """Mock a YouLess device."""
+
+    class Dummy:
+        async def start_server(self):
+            raise HTTPError
+
+        async def close_server(self):
+            pass
+
+    server = Dummy()
+    with patch(
+        "homeassistant.components.youless.config_flow.YoulessAPI", return_value=server
+    ):
+        yield server
+
+
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
+    """Check setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == config_entries.SOURCE_USER
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_CONFIG,
+    )
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY


### PR DESCRIPTION
I would love to see this in home assistant core and read your comments in the original pull request.

I investigated the problem with the unit test and found that for the api provided via MagicMock in the unit test the attribute `api.mac_adress` is not `None`, but a `MagicMock` object. This is passed in the `data` dictionary into `async_create_entry`, yielding the problem as this dictionary is not JSON serializable. As simple fix I have added a check if `api.mac_address` is actually a string.